### PR TITLE
MS1: Fixed Idle Dash behavior and implemented Ceiling Detection

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -1,5 +1,36 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1160130673268404248
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8115639321017588057}
+  m_Layer: 0
+  m_Name: CeilingCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8115639321017588057
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1160130673268404248}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6021121037186470622}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3674978410278467123
 GameObject:
   m_ObjectHideFlags: 0
@@ -32,6 +63,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2532919520594844671}
+  - {fileID: 8115639321017588057}
   - {fileID: 1826690567408928504}
   - {fileID: 5568228374321307106}
   m_Father: {fileID: 0}
@@ -74,18 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 29ea5f67317c5f645b5a098b0df68db2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 5
-  gravity: -50
-  maxFallSpeed: -20
-  jumpHeight: 1
-  jumpBoost: 30
-  dashSpeed: 20
-  dashCooldown: 1
-  dashDuration: 0.1
-  dashMiniBoost: 5
-  coyoteTime: 0.1
-  jumpBuffer: 0.15
-  glideEffectiveness: 0.9
   layerMask:
     serializedVersion: 2
     m_Bits: 8

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -9,6 +9,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8115639321017588057}
+  - component: {fileID: 7295353354966305650}
+  - component: {fileID: 6234096934089925210}
   m_Layer: 0
   m_Name: CeilingCheck
   m_TagString: Untagged
@@ -31,6 +33,40 @@ Transform:
   m_Children: []
   m_Father: {fileID: 6021121037186470622}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &7295353354966305650
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1160130673268404248}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 0.14418873, z: 1}
+  m_Center: {x: 0, y: 0.42790562, z: 0}
+--- !u!114 &6234096934089925210
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1160130673268404248}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d6c6605a755cec944a8e8ed77edca341, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerMovement: {fileID: 2948422166326687479}
 --- !u!1 &3674978410278467123
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player Scripts/CeilingCheck.cs
+++ b/Assets/Scripts/Player Scripts/CeilingCheck.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CeilingCheck : MonoBehaviour
+{
+    public Movement playerMovement;
+
+    private void OnTriggerEnter(Collider other)
+    {
+        Debug.Log("Ceiling Collision Occurred");
+        playerMovement.OnCeilingCollision();
+    }
+}

--- a/Assets/Scripts/Player Scripts/CeilingCheck.cs.meta
+++ b/Assets/Scripts/Player Scripts/CeilingCheck.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6c6605a755cec944a8e8ed77edca341
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player Scripts/Movement.cs
+++ b/Assets/Scripts/Player Scripts/Movement.cs
@@ -8,8 +8,9 @@ public class Movement : MonoBehaviour
 {
     private float moveX, moveY, dashCD, coyoteCD, jumpBufferCD, useMaxFallSpeed;
 
-    private bool isGrounded, isDashing, dashedInAir;
-    private bool facingRight = true;
+    private bool isGrounded, isDashing, dashedInAir,
+        jumpApexReached = false,
+        facingRight = true;
     
     public LayerMask layerMask;
 
@@ -65,9 +66,19 @@ public class Movement : MonoBehaviour
 
             if (Input.GetKey(KeyCode.Space) && !isDashing)
             {
+                // During Jump
                 if (moveY >= 0f)
                 {
-                    moveY += jumpBoost * Time.deltaTime;
+                    // if still accelerating up
+                    if (!jumpApexReached)
+                    {
+                        moveY += jumpBoost * Time.deltaTime;
+                    }
+                    else
+                    {
+                        moveY = -1f;
+                    }
+                    
                 }
             }
             else
@@ -95,6 +106,7 @@ public class Movement : MonoBehaviour
         {
             controller.Move(Vector2.up * moveY * Time.deltaTime);
 
+            jumpApexReached = (controller.velocity.y <= 0f) ?  true : false;
 
             if (moveY >= useMaxFallSpeed)
             {

--- a/Assets/Scripts/Player Scripts/Movement.cs
+++ b/Assets/Scripts/Player Scripts/Movement.cs
@@ -84,6 +84,7 @@ public class Movement : MonoBehaviour
             else
             {
                 useMaxFallSpeed = maxFallSpeed;
+                jumpApexReached = true;
             }
 
             if (Input.GetKey(KeyCode.W) && !isDashing)
@@ -175,6 +176,12 @@ public class Movement : MonoBehaviour
         {
             jumpBufferCD -= Time.deltaTime;
         }
+    }
+
+    public void OnCeilingCollision()
+    {
+        moveY = 0f;
+        jumpApexReached = true;
     }
 
     private void Teleport(Vector3 targetPosition)

--- a/Assets/Scripts/Player Scripts/Movement.cs
+++ b/Assets/Scripts/Player Scripts/Movement.cs
@@ -7,8 +7,9 @@ using UnityEngine.Animations;
 public class Movement : MonoBehaviour
 {
     private float moveX, moveY, dashCD, coyoteCD, jumpBufferCD, useMaxFallSpeed;
-    
+
     private bool isGrounded, isDashing, dashedInAir;
+    private bool facingRight = true;
     
     public LayerMask layerMask;
 
@@ -116,11 +117,18 @@ public class Movement : MonoBehaviour
         // Dash
         moveX = Input.GetAxis("Horizontal");
 
+        // Saving the last direction moved
+        if(moveX != 0f)
+        {
+            facingRight = (moveX > 0f) ? true : false;
+        }
+
         if (Input.GetKeyDown(KeyCode.LeftShift) && dashCD <= 0f && !dashedInAir)
         {
                 isDashing = true;
                 dashCD = dashCooldown;
-                dashDirection = (Vector2.right * moveX) / Mathf.Abs(moveX);
+                Vector2 facingDirection = facingRight ? Vector2.right : Vector2.left;
+                dashDirection = facingDirection;
                 dashedInAir = true;
         }
 


### PR DESCRIPTION
## Idle Dash: 
* When the player is idle, they now dash in the last direction they moved. If the player hasn't moved, they'll dash to the right.
* I created the variable `facingRight` in the `Movement` script to hold the last direction faced.

## Ceiling Detection during a jump:
* When the player hits a ceiling during a jump, their y velocity is set to 0f.

Specifics:
* I created the `CeilingDetection` script and added it to a gameObject called _CeilingDetector_ and nested it under the _Player_ gameObject.
* The `CeilingDetection` script listens to when this gameObject collides with another object. When this occurs, the script calls the `OnCeilingCollision()` method from the `Movement` class to set velocity to 0f.
