### PR TITLE
Fixed Spore's Collision

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 8185719849261634161}
   m_Layer: 0
   m_Name: CeilingCheck
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -707,7 +707,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enemyImmunity: 2
-  enemy: {fileID: 4583454541530764110, guid: 81a0dc95c9ba1aa4ca2300bb54a61ac4, type: 3}
 --- !u!114 &3535977446438047488
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Spores/Spore.cs
+++ b/Assets/Scripts/Spores/Spore.cs
@@ -35,8 +35,9 @@ public class Spore : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
-        Movement player = other.gameObject.GetComponent<Movement>();
-        if(player == null)
+        if (other.isTrigger) { return; }
+
+        if(!other.CompareTag("Player"))
         {
             SporeCollisionEvents();
             Destroy(gameObject);


### PR DESCRIPTION
The spore will no longer collide with other triggers (such as enemy radius detectors).

The Spore script also now detects for the player using the Player tag, rather than by Movement script. This allows the spore to pass through the player's "ceiling check" collider, which is nested under the player.