### PR TITLE
Multi-fire for Fire Spores, Spore Charge Bars

### DIFF
--- a/Assets/Prefabs/Spores/FireSporeItem.prefab
+++ b/Assets/Prefabs/Spores/FireSporeItem.prefab
@@ -49,7 +49,7 @@ MonoBehaviour:
   sporeType: 1
   SelectSound: {fileID: 0}
   maxCharge: 100
-  currentCharge: 0
+  currentCharge: 100
   chargeTakenPerUse: 25
   chargeDelay: 0
   rechargeRatePerSec: 0

--- a/Assets/Prefabs/Spores/FireSporeItem.prefab
+++ b/Assets/Prefabs/Spores/FireSporeItem.prefab
@@ -51,5 +51,5 @@ MonoBehaviour:
   maxCharge: 100
   currentCharge: 100
   chargeTakenPerUse: 25
-  chargeDelay: 0
-  rechargeRatePerSec: 0
+  chargeDelay: 3
+  rechargeRatePerSec: 20

--- a/Assets/Prefabs/Spores/FireSporeItem.prefab
+++ b/Assets/Prefabs/Spores/FireSporeItem.prefab
@@ -51,5 +51,5 @@ MonoBehaviour:
   maxCharge: 100
   currentCharge: 100
   chargeTakenPerUse: 25
-  chargeDelay: 0
-  rechargeRatePerSec: 0
+  chargeDelay: 3
+  rechargeRatePerSec: 33

--- a/Assets/Prefabs/Spores/FireSporeItem.prefab
+++ b/Assets/Prefabs/Spores/FireSporeItem.prefab
@@ -45,6 +45,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sporeSprite: {fileID: 21300000, guid: 9ecd1fb0c40fc37449eaabb247f98df3, type: 3}
-  sporePrefab: {fileID: 0}
+  sporePrefab: {fileID: -5405109077534043659, guid: 5383a29ce2f64a849a8e82382e6e85ae, type: 3}
   sporeType: 1
   SelectSound: {fileID: 0}
+  maxCharge: 100
+  currentCharge: 0
+  chargeTakenPerUse: 25
+  chargeDelay: 0
+  rechargeRatePerSec: 0

--- a/Assets/Prefabs/Spores/IceSporeItem.prefab
+++ b/Assets/Prefabs/Spores/IceSporeItem.prefab
@@ -50,6 +50,6 @@ MonoBehaviour:
   SelectSound: {fileID: 0}
   maxCharge: 100
   currentCharge: 100
-  chargeTakenPerUse: 0
+  chargeTakenPerUse: 100
   chargeDelay: 0
   rechargeRatePerSec: 0

--- a/Assets/Prefabs/Spores/IceSporeItem.prefab
+++ b/Assets/Prefabs/Spores/IceSporeItem.prefab
@@ -48,3 +48,8 @@ MonoBehaviour:
   sporePrefab: {fileID: 0}
   sporeType: 2
   SelectSound: {fileID: 0}
+  maxCharge: 100
+  currentCharge: 100
+  chargeTakenPerUse: 0
+  chargeDelay: 0
+  rechargeRatePerSec: 0

--- a/Assets/Prefabs/Spores/IceSporeItem.prefab
+++ b/Assets/Prefabs/Spores/IceSporeItem.prefab
@@ -45,7 +45,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sporeSprite: {fileID: 21300000, guid: 2a193b1eca6aec948b3b8278043263ff, type: 3}
-  sporePrefab: {fileID: 0}
+  sporePrefab: {fileID: 6170800030019777992, guid: 44ea2f715974683488559ab2d6410186, type: 3}
   sporeType: 2
   SelectSound: {fileID: 0}
   maxCharge: 100

--- a/Assets/Prefabs/Spores/NormalSporeItem.prefab
+++ b/Assets/Prefabs/Spores/NormalSporeItem.prefab
@@ -51,5 +51,5 @@ MonoBehaviour:
   maxCharge: 100
   currentCharge: 100
   chargeTakenPerUse: 50
-  chargeDelay: 3
+  chargeDelay: 1
   rechargeRatePerSec: 10

--- a/Assets/Prefabs/Spores/NormalSporeItem.prefab
+++ b/Assets/Prefabs/Spores/NormalSporeItem.prefab
@@ -45,7 +45,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sporeSprite: {fileID: 21300000, guid: 741ab30eb2549084f9e510f9017fdf23, type: 3}
-  sporePrefab: {fileID: 0}
+  sporePrefab: {fileID: 4104357072703201290, guid: b8dd7e2399295cd41bedd470d3442ebb, type: 3}
   sporeType: 0
   SelectSound: {fileID: 0}
   maxCharge: 100

--- a/Assets/Prefabs/Spores/NormalSporeItem.prefab
+++ b/Assets/Prefabs/Spores/NormalSporeItem.prefab
@@ -48,3 +48,8 @@ MonoBehaviour:
   sporePrefab: {fileID: 0}
   sporeType: 0
   SelectSound: {fileID: 0}
+  maxCharge: 100
+  currentCharge: 100
+  chargeTakenPerUse: 0
+  chargeDelay: 0
+  rechargeRatePerSec: 0

--- a/Assets/Prefabs/Spores/NormalSporeItem.prefab
+++ b/Assets/Prefabs/Spores/NormalSporeItem.prefab
@@ -50,6 +50,6 @@ MonoBehaviour:
   SelectSound: {fileID: 0}
   maxCharge: 100
   currentCharge: 100
-  chargeTakenPerUse: 0
-  chargeDelay: 0
-  rechargeRatePerSec: 0
+  chargeTakenPerUse: 50
+  chargeDelay: 3
+  rechargeRatePerSec: 10

--- a/Assets/Prefabs/UI/Canvas Spores.prefab
+++ b/Assets/Prefabs/UI/Canvas Spores.prefab
@@ -552,6 +552,44 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7895487139434833270
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 832825709940827588}
+  m_Layer: 5
+  m_Name: SporeItems
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &832825709940827588
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7895487139434833270}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 113466935078672966}
+  - {fileID: 4474201438696216025}
+  - {fileID: 3810195423350483925}
+  m_Father: {fileID: 5029110947898369786}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &9093039281140066007
 GameObject:
   m_ObjectHideFlags: 0
@@ -588,6 +626,7 @@ RectTransform:
   - {fileID: 5987432736689516437}
   - {fileID: 2138233116716371804}
   - {fileID: 2685727433695143915}
+  - {fileID: 832825709940827588}
   m_Father: {fileID: 4921355859641877321}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -607,13 +646,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1ee9be40fc2a0ca4c95c64a6b4cb5c56, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  mainSpore: {fileID: 0}
   mainSporeSlot: {fileID: 5906815340232312938}
   leftSporeSlot: {fileID: 7389057167907255866}
   rightSporeSlot: {fileID: 2694412680516413936}
   sporesList:
-  - {fileID: 1988315706807273614, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
-  - {fileID: 1988315706807273614, guid: a70297750074dfb418853548d789c9e9, type: 3}
-  - {fileID: 1988315706807273614, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+  - {fileID: 1887947860662420724}
+  - {fileID: 3404936327840150887}
+  - {fileID: 2717858057398012779}
   animator: {fileID: 4961562909784856634}
 --- !u!95 &4961562909784856634
 Animator:
@@ -636,3 +676,222 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!1001 &118426242841955450
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 832825709940827588}
+    m_Modifications:
+    - target: {fileID: 15658805974013500, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7891780816232665862, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: m_Name
+      value: FireSporeItem
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+--- !u!4 &113466935078672966 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 15658805974013500, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+  m_PrefabInstance: {fileID: 118426242841955450}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1887947860662420724 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1988315706807273614, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+  m_PrefabInstance: {fileID: 118426242841955450}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c66a2a75b222904da538ed03d4e0e8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &3807557180172795369
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 832825709940827588}
+    m_Modifications:
+    - target: {fileID: 15658805974013500, guid: a70297750074dfb418853548d789c9e9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: a70297750074dfb418853548d789c9e9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: a70297750074dfb418853548d789c9e9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: a70297750074dfb418853548d789c9e9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: a70297750074dfb418853548d789c9e9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: a70297750074dfb418853548d789c9e9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: a70297750074dfb418853548d789c9e9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: a70297750074dfb418853548d789c9e9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: a70297750074dfb418853548d789c9e9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: a70297750074dfb418853548d789c9e9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7891780816232665862, guid: a70297750074dfb418853548d789c9e9, type: 3}
+      propertyPath: m_Name
+      value: NormalSporeItem
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a70297750074dfb418853548d789c9e9, type: 3}
+--- !u!114 &3404936327840150887 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1988315706807273614, guid: a70297750074dfb418853548d789c9e9, type: 3}
+  m_PrefabInstance: {fileID: 3807557180172795369}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c66a2a75b222904da538ed03d4e0e8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &3810195423350483925 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 15658805974013500, guid: a70297750074dfb418853548d789c9e9, type: 3}
+  m_PrefabInstance: {fileID: 3807557180172795369}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4476629814307423205
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 832825709940827588}
+    m_Modifications:
+    - target: {fileID: 15658805974013500, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 15658805974013500, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7891780816232665862, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+      propertyPath: m_Name
+      value: IceSporeItem
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+--- !u!114 &2717858057398012779 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1988315706807273614, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+  m_PrefabInstance: {fileID: 4476629814307423205}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c66a2a75b222904da538ed03d4e0e8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &4474201438696216025 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 15658805974013500, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+  m_PrefabInstance: {fileID: 4476629814307423205}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/UI/Canvas Spores.prefab
+++ b/Assets/Prefabs/UI/Canvas Spores.prefab
@@ -663,6 +663,9 @@ MonoBehaviour:
   mainSporeSlot: {fileID: 5906815340232312938}
   leftSporeSlot: {fileID: 7389057167907255866}
   rightSporeSlot: {fileID: 2694412680516413936}
+  mainSporeItemUI: {fileID: 0}
+  leftSporeItemUI: {fileID: 0}
+  rightSporeItemUI: {fileID: 0}
   sporesList:
   - {fileID: 1887947860662420724}
   - {fileID: 3404936327840150887}

--- a/Assets/Prefabs/UI/Canvas Spores.prefab
+++ b/Assets/Prefabs/UI/Canvas Spores.prefab
@@ -75,6 +75,184 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &905292436696706713
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 122614794943540150}
+  - component: {fileID: 3294669404900172822}
+  m_Layer: 5
+  m_Name: Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &122614794943540150
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 905292436696706713}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8824124917352186128}
+  m_Father: {fileID: 2138233116716371804}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3294669404900172822
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 905292436696706713}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 2455444627291056035}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 3
+  m_MinValue: 0
+  m_MaxValue: 100
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &1071591984681689251
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3108514636641715999}
+  - component: {fileID: 6805400793256365602}
+  - component: {fileID: 3633402293209223247}
+  - component: {fileID: 5147112146035172840}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3108514636641715999
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071591984681689251}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 6, y: 6, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 181452061860509997}
+  m_Father: {fileID: 1928431030424888224}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.25, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6805400793256365602
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071591984681689251}
+  m_CullTransparentMesh: 1
+--- !u!114 &3633402293209223247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071591984681689251}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 741ab30eb2549084f9e510f9017fdf23, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5147112146035172840
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071591984681689251}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 1
 --- !u!1 &1781755380617134137
 GameObject:
   m_ObjectHideFlags: 0
@@ -85,7 +263,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2685727433695143915}
   - component: {fileID: 6381924288513177584}
-  - component: {fileID: 5906815340232312938}
+  - component: {fileID: 5746380595331894904}
   m_Layer: 5
   m_Name: Main Spore
   m_TagString: Untagged
@@ -104,7 +282,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1928431030424888224}
   m_Father: {fileID: 5029110947898369786}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -120,7 +299,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1781755380617134137}
   m_CullTransparentMesh: 1
---- !u!114 &5906815340232312938
+--- !u!114 &5746380595331894904
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -129,27 +308,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1781755380617134137}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 9c772d0fbcaa7bf49a1b6f3c27bfe96f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 741ab30eb2549084f9e510f9017fdf23, type: 3}
-  m_Type: 3
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 45
+  chargebar: {fileID: 6808982327982676486}
+  fill: {fileID: 8915625492466132391}
+  sliderImageSlot: {fileID: 3633402293209223247}
+  sporeItem: {fileID: 3404936327840150887}
 --- !u!1 &2739347012845057381
 GameObject:
   m_ObjectHideFlags: 0
@@ -262,7 +427,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2138233116716371804}
   - component: {fileID: 8485192840687890707}
-  - component: {fileID: 7389057167907255866}
+  - component: {fileID: 8320746615978378724}
   m_Layer: 5
   m_Name: Left Spore
   m_TagString: Untagged
@@ -281,7 +446,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 122614794943540150}
   m_Father: {fileID: 5029110947898369786}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -297,7 +463,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2900510572868938455}
   m_CullTransparentMesh: 1
---- !u!114 &7389057167907255866
+--- !u!114 &8320746615978378724
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -306,27 +472,49 @@ MonoBehaviour:
   m_GameObject: {fileID: 2900510572868938455}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 9c772d0fbcaa7bf49a1b6f3c27bfe96f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 9ecd1fb0c40fc37449eaabb247f98df3, type: 3}
-  m_Type: 3
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  chargebar: {fileID: 3294669404900172822}
+  fill: {fileID: 3105292318331662870}
+  sliderImageSlot: {fileID: 7443747657544902454}
+  sporeItem: {fileID: 0}
+--- !u!1 &2968813424674668205
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9168327300120024764}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9168327300120024764
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2968813424674668205}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.18, y: 0.22, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 160944840702239479}
+  m_Father: {fileID: 8698706177866063628}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.25, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0.83333206}
+  m_SizeDelta: {x: 40, y: -20}
+  m_Pivot: {x: 0.51, y: 0.48}
 --- !u!1 &3829830264435314511
 GameObject:
   m_ObjectHideFlags: 0
@@ -402,6 +590,282 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3904316789479963271
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8824124917352186128}
+  - component: {fileID: 8162670842494857871}
+  - component: {fileID: 7443747657544902454}
+  - component: {fileID: 115079108674998560}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8824124917352186128
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3904316789479963271}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 6, y: 6, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1261743996191695675}
+  m_Father: {fileID: 122614794943540150}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.25, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8162670842494857871
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3904316789479963271}
+  m_CullTransparentMesh: 1
+--- !u!114 &7443747657544902454
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3904316789479963271}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 741ab30eb2549084f9e510f9017fdf23, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &115079108674998560
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3904316789479963271}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 1
+--- !u!1 &3966690012064281820
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 585729278775099860}
+  - component: {fileID: 2930838156644738203}
+  - component: {fileID: 8915625492466132391}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &585729278775099860
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3966690012064281820}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 181452061860509997}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 10}
+  m_Pivot: {x: 0.5, y: -0.2}
+--- !u!222 &2930838156644738203
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3966690012064281820}
+  m_CullTransparentMesh: 1
+--- !u!114 &8915625492466132391
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3966690012064281820}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.78431374}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4029470238093597715
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 160944840702239479}
+  - component: {fileID: 3536338669916956733}
+  - component: {fileID: 7878146366739657126}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &160944840702239479
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4029470238093597715}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9168327300120024764}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 10}
+  m_Pivot: {x: 0.5, y: -0.2}
+--- !u!222 &3536338669916956733
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4029470238093597715}
+  m_CullTransparentMesh: 1
+--- !u!114 &7878146366739657126
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4029470238093597715}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.78431374}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4195936322527271930
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 181452061860509997}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &181452061860509997
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4195936322527271930}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.18, y: 0.22, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 585729278775099860}
+  m_Father: {fileID: 3108514636641715999}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.25, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0.83333206}
+  m_SizeDelta: {x: 40, y: -20}
+  m_Pivot: {x: 0.51, y: 0.48}
 --- !u!1 &6368860525432067247
 GameObject:
   m_ObjectHideFlags: 0
@@ -412,7 +876,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5987432736689516437}
   - component: {fileID: 2820506448332524620}
-  - component: {fileID: 2694412680516413936}
+  - component: {fileID: 6329004096997369883}
   m_Layer: 5
   m_Name: Right Spore
   m_TagString: Untagged
@@ -431,7 +895,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 9144524910207228611}
   m_Father: {fileID: 5029110947898369786}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -447,7 +912,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6368860525432067247}
   m_CullTransparentMesh: 1
---- !u!114 &2694412680516413936
+--- !u!114 &6329004096997369883
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -455,6 +920,157 @@ MonoBehaviour:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6368860525432067247}
   m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9c772d0fbcaa7bf49a1b6f3c27bfe96f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  chargebar: {fileID: 3252268735966222668}
+  fill: {fileID: 7878146366739657126}
+  sliderImageSlot: {fileID: 2532153062582674204}
+  sporeItem: {fileID: 3404936327840150887}
+--- !u!1 &6499057039598151779
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1928431030424888224}
+  - component: {fileID: 6808982327982676486}
+  m_Layer: 5
+  m_Name: Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1928431030424888224
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6499057039598151779}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3108514636641715999}
+  m_Father: {fileID: 2685727433695143915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &6808982327982676486
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6499057039598151779}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 585729278775099860}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 3
+  m_MinValue: 0
+  m_MaxValue: 100
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &6972062417562712525
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8698706177866063628}
+  - component: {fileID: 3779055425429558001}
+  - component: {fileID: 2532153062582674204}
+  - component: {fileID: 6905662566291881173}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8698706177866063628
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6972062417562712525}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 6, y: 6, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9168327300120024764}
+  m_Father: {fileID: 9144524910207228611}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.25, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3779055425429558001
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6972062417562712525}
+  m_CullTransparentMesh: 1
+--- !u!114 &2532153062582674204
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6972062417562712525}
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
@@ -467,8 +1083,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 2a193b1eca6aec948b3b8278043263ff, type: 3}
-  m_Type: 3
+  m_Sprite: {fileID: 21300000, guid: 9ecd1fb0c40fc37449eaabb247f98df3, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -477,6 +1093,19 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6905662566291881173
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6972062417562712525}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 1
 --- !u!1 &7106415028610968435
 GameObject:
   m_ObjectHideFlags: 0
@@ -603,6 +1232,205 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bb6c33fea96540b48a1189e87dd5e92b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &8062830075516509497
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2455444627291056035}
+  - component: {fileID: 5698926512629988662}
+  - component: {fileID: 3105292318331662870}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2455444627291056035
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8062830075516509497}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1261743996191695675}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 10}
+  m_Pivot: {x: 0.5, y: -0.2}
+--- !u!222 &5698926512629988662
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8062830075516509497}
+  m_CullTransparentMesh: 1
+--- !u!114 &3105292318331662870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8062830075516509497}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.78431374}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8148005751010464756
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9144524910207228611}
+  - component: {fileID: 3252268735966222668}
+  m_Layer: 5
+  m_Name: Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9144524910207228611
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8148005751010464756}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8698706177866063628}
+  m_Father: {fileID: 5987432736689516437}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3252268735966222668
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8148005751010464756}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 160944840702239479}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 3
+  m_MinValue: 0
+  m_MaxValue: 100
+  m_WholeNumbers: 0
+  m_Value: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &8821139810491287047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1261743996191695675}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1261743996191695675
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8821139810491287047}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.18, y: 0.22, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2455444627291056035}
+  m_Father: {fileID: 8824124917352186128}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.25, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0.83333206}
+  m_SizeDelta: {x: 40, y: -20}
+  m_Pivot: {x: 0.51, y: 0.48}
 --- !u!1 &9093039281140066007
 GameObject:
   m_ObjectHideFlags: 0
@@ -659,17 +1487,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1ee9be40fc2a0ca4c95c64a6b4cb5c56, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mainSpore: {fileID: 0}
-  mainSporeSlot: {fileID: 5906815340232312938}
-  leftSporeSlot: {fileID: 7389057167907255866}
-  rightSporeSlot: {fileID: 2694412680516413936}
-  mainSporeItemUI: {fileID: 0}
-  leftSporeItemUI: {fileID: 0}
-  rightSporeItemUI: {fileID: 0}
+  mainSpore: {fileID: 3404936327840150887}
+  mainSporeItemUI: {fileID: 5746380595331894904}
+  leftSporeItemUI: {fileID: 8320746615978378724}
+  rightSporeItemUI: {fileID: 6329004096997369883}
   sporesList:
-  - {fileID: 1887947860662420724}
   - {fileID: 3404936327840150887}
-  - {fileID: 2717858057398012779}
   animator: {fileID: 4961562909784856634}
 --- !u!95 &4961562909784856634
 Animator:
@@ -766,17 +1589,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 15658805974013500, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
   m_PrefabInstance: {fileID: 118426242841955450}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1887947860662420724 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1988315706807273614, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
-  m_PrefabInstance: {fileID: 118426242841955450}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2c66a2a75b222904da538ed03d4e0e8f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &3807557180172795369
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -915,17 +1727,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
---- !u!114 &2717858057398012779 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1988315706807273614, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
-  m_PrefabInstance: {fileID: 4476629814307423205}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2c66a2a75b222904da538ed03d4e0e8f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &4474201438696216025 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 15658805974013500, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}

--- a/Assets/Prefabs/UI/Canvas Spores.prefab
+++ b/Assets/Prefabs/UI/Canvas Spores.prefab
@@ -561,6 +561,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 832825709940827588}
+  - component: {fileID: 4415852357029217973}
   m_Layer: 5
   m_Name: SporeItems
   m_TagString: Untagged
@@ -590,6 +591,18 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4415852357029217973
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7895487139434833270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb6c33fea96540b48a1189e87dd5e92b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &9093039281140066007
 GameObject:
   m_ObjectHideFlags: 0
@@ -724,6 +737,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1988315706807273614, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: chargeDelay
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1988315706807273614, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: sporePrefab
+      value: 
+      objectReference: {fileID: -5405109077534043659, guid: 5383a29ce2f64a849a8e82382e6e85ae, type: 3}
+    - target: {fileID: 1988315706807273614, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
+      propertyPath: rechargeRatePerSec
+      value: 40
+      objectReference: {fileID: 0}
     - target: {fileID: 7891780816232665862, guid: f5f82bd537394b043ace754fca7c6807, type: 3}
       propertyPath: m_Name
       value: FireSporeItem
@@ -797,6 +822,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1988315706807273614, guid: a70297750074dfb418853548d789c9e9, type: 3}
+      propertyPath: sporePrefab
+      value: 
+      objectReference: {fileID: 4104357072703201290, guid: b8dd7e2399295cd41bedd470d3442ebb, type: 3}
     - target: {fileID: 7891780816232665862, guid: a70297750074dfb418853548d789c9e9, type: 3}
       propertyPath: m_Name
       value: NormalSporeItem
@@ -870,6 +899,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1988315706807273614, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
+      propertyPath: sporePrefab
+      value: 
+      objectReference: {fileID: 6170800030019777992, guid: 44ea2f715974683488559ab2d6410186, type: 3}
     - target: {fileID: 7891780816232665862, guid: 28f6466bd79a5fb43ab4a8eff334171a, type: 3}
       propertyPath: m_Name
       value: IceSporeItem

--- a/Assets/Scenes/Game Scenes/Spore Level.unity
+++ b/Assets/Scenes/Game Scenes/Spore Level.unity
@@ -320,10 +320,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8679484668022479062, guid: ca6ca03f17dcda74c9d4c663d6be2d31, type: 3}
-      propertyPath: sporesList.Array.size
-      value: 2
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Scripts/Player Scripts/SporeTrajectoryRenderer.cs
+++ b/Assets/Scripts/Player Scripts/SporeTrajectoryRenderer.cs
@@ -28,7 +28,6 @@ public class SporeTrajectoryRenderer : MonoBehaviour
         Vector3 gravity = new Vector3(0, customGravity, 0);
         float throwForce = throwTest.currentSpore.GetThrowSpeed();
         Vector3 direction = throwTest.direction.normalized;
-        direction = new Vector3(direction.y, -direction.x, 0);
 
         Vector3 launchVelocity = direction * throwForce;
         Vector3 position = Vector3.zero;

--- a/Assets/Scripts/Player Scripts/ThrowManager.cs
+++ b/Assets/Scripts/Player Scripts/ThrowManager.cs
@@ -21,7 +21,7 @@ public class ThrowManager : MonoBehaviour
     {
         mainCamera = Camera.main;
         onCooldown = false;
-        Spore.OnSporeDestroyed += StartCooldown;
+        //Spore.OnSporeDestroyed += StartCooldown;
     }
 
     /// <summary>

--- a/Assets/Scripts/Player Scripts/ThrowTest.cs
+++ b/Assets/Scripts/Player Scripts/ThrowTest.cs
@@ -76,27 +76,10 @@ public class ThrowTest : MonoBehaviour
             //Wont shoot anything if on cooldown or you have no spore.
             if(Spore.instance == null && !onCooldown)
             {
-                if (currentSpore == teleportSporePrefab)
-                {
-                    Spore sporeThrown = Instantiate(teleportSporePrefab, transform.position, Quaternion.identity);
-                    sporeTrajectoryRenderer.enabled = false;
-                    sporeThrown.AddImpulse(throwDirection, teleportSporePrefab.GetThrowSpeed());
-                    StartCoroutine(sporeThrown.Lifespan(sporeFlightDuration));
-                }
-                if (currentSpore == fireSporePrefab)
-                {
-                    Spore sporeThrown = Instantiate(fireSporePrefab, transform.position, Quaternion.identity);
-                    sporeTrajectoryRenderer.enabled = false;
-                    sporeThrown.AddImpulse(throwDirection, fireSporePrefab.GetThrowSpeed());
-                    StartCoroutine(sporeThrown.Lifespan(sporeFlightDuration));
-                }
-                if (currentSpore == cordycepsSporePrefab)
-                {
-                    Spore sporeThrown = Instantiate(cordycepsSporePrefab, transform.position, Quaternion.identity);
-                    sporeTrajectoryRenderer.enabled = false;
-                    sporeThrown.AddImpulse(throwDirection, cordycepsSporePrefab.GetThrowSpeed());
-                    StartCoroutine(sporeThrown.Lifespan(sporeFlightDuration));
-                }
+                Spore sporeThrown = Instantiate(currentSpore, transform.position, Quaternion.identity);
+                sporeTrajectoryRenderer.enabled = false;
+                sporeThrown.AddImpulse(throwDirection, teleportSporePrefab.GetThrowSpeed());
+                StartCoroutine(sporeThrown.Lifespan(sporeFlightDuration));
             }
         } else {
             cancel = false; // allows for shooting to be used again.

--- a/Assets/Scripts/Player Scripts/ThrowTest.cs
+++ b/Assets/Scripts/Player Scripts/ThrowTest.cs
@@ -31,7 +31,6 @@ public class ThrowTest : MonoBehaviour
         instance = this;
         mainCamera = Camera.main;
         onCooldown = false;
-        Spore.OnSporeDestroyed += StartCooldown;
     }
 
     private void Start()
@@ -64,26 +63,22 @@ public class ThrowTest : MonoBehaviour
             sporeTrajectoryRenderer.enabled = false;
             if (SporeItemManager.instance.CanThrow())
             {
-                ThrowSpore();
+                Spore sporeToThrow = SporeItemManager.instance.GetCurrentSpore();
+                ThrowSpore(sporeToThrow);
             }
 
         }
     }
 
-    private void ThrowSpore(){
+    private void ThrowSpore(Spore sporePrefab){
         if(!cancel){
             //These get the direction of where the mouse is for the spore to shoot will only run if it isn't canceled.
             
             //Wont shoot anything if on cooldown or you have no spore.
-            if(Spore.instance == null && !onCooldown)
-            {
-                Spore sporeThrown = Instantiate(currentSpore, transform.position, Quaternion.identity);
-                sporeTrajectoryRenderer.enabled = false;
-                sporeThrown.AddImpulse(direction, teleportSporePrefab.GetThrowSpeed());
-                StartCoroutine(sporeThrown.Lifespan(sporeFlightDuration));
-
-                SporeItemManager.instance.PayCharge();
-            }
+            Spore sporeThrown = Instantiate(sporePrefab, transform.position, Quaternion.identity);
+            sporeTrajectoryRenderer.enabled = false;
+            sporeThrown.AddImpulse(direction, sporePrefab.GetThrowSpeed());
+            StartCoroutine(sporeThrown.Lifespan(sporeFlightDuration));
         } else {
             cancel = false; // allows for shooting to be used again.
         }
@@ -91,7 +86,7 @@ public class ThrowTest : MonoBehaviour
     }
 
     //Cooldown functions for shooting and function for sword to not swing when cancelling shot.
-    private void StartCooldown() => StartCoroutine(StartCooldownHelper());
+    public void StartCooldown() => StartCoroutine(StartCooldownHelper());
     private IEnumerator StartCooldownHelper()
     {
         onCooldown = true;

--- a/Assets/Scripts/Player Scripts/ThrowTest.cs
+++ b/Assets/Scripts/Player Scripts/ThrowTest.cs
@@ -41,14 +41,15 @@ public class ThrowTest : MonoBehaviour
 
     void Update()
     {
-        Vector3 mouseScreenPosition = Input.mousePosition;
-        Vector3 clickedPos = mainCamera.ScreenToWorldPoint(new Vector3(mouseScreenPosition.x, mouseScreenPosition.y, mainCamera.transform.position.z * -1f));
-
-        direction = clickedPos - this.transform.position;
-        direction = new Vector3(-direction.y, direction.x, 0);
+        
 
         if (Input.GetMouseButton(1) && !cancel)
         {
+            Vector3 mouseScreenPosition = Input.mousePosition;
+            Vector3 clickedPos = mainCamera.ScreenToWorldPoint(new Vector3(mouseScreenPosition.x, mouseScreenPosition.y, mainCamera.transform.position.z * -1f));
+
+            direction = (clickedPos - this.transform.position).normalized;
+
             shooting = true;
             if (Input.GetMouseButtonDown(0))
             {
@@ -61,25 +62,27 @@ public class ThrowTest : MonoBehaviour
         if (Input.GetMouseButtonUp(1))
         {
             sporeTrajectoryRenderer.enabled = false;
-            ThrowSpore();
+            if (SporeItemManager.instance.CanThrow())
+            {
+                ThrowSpore();
+            }
+
         }
     }
 
     private void ThrowSpore(){
         if(!cancel){
             //These get the direction of where the mouse is for the spore to shoot will only run if it isn't canceled.
-            Vector3 mouseScreenPosition = Input.mousePosition;
-            Vector3 clickedPos = mainCamera.ScreenToWorldPoint(new Vector3(mouseScreenPosition.x, mouseScreenPosition.y, mainCamera.transform.position.z * -1f));
-
-            Vector3 throwDirection = new Vector3(clickedPos.x - transform.position.x, clickedPos.y - transform.position.y).normalized;
             
             //Wont shoot anything if on cooldown or you have no spore.
             if(Spore.instance == null && !onCooldown)
             {
                 Spore sporeThrown = Instantiate(currentSpore, transform.position, Quaternion.identity);
                 sporeTrajectoryRenderer.enabled = false;
-                sporeThrown.AddImpulse(throwDirection, teleportSporePrefab.GetThrowSpeed());
+                sporeThrown.AddImpulse(direction, teleportSporePrefab.GetThrowSpeed());
                 StartCoroutine(sporeThrown.Lifespan(sporeFlightDuration));
+
+                SporeItemManager.instance.PayCharge();
             }
         } else {
             cancel = false; // allows for shooting to be used again.

--- a/Assets/Scripts/Spores/FireSpore.cs
+++ b/Assets/Scripts/Spores/FireSpore.cs
@@ -23,6 +23,11 @@ public class FireSpore : Spore
 
         if(other.gameObject.tag == "Vines"){
             Destroy(other.gameObject);
+        }
+
+        if(!other.CompareTag("Player") && !other.isTrigger)
+        {
+            SporeCollisionEvents();
             Destroy(gameObject);
         }
     }

--- a/Assets/Scripts/Spores/Spore.cs
+++ b/Assets/Scripts/Spores/Spore.cs
@@ -4,8 +4,8 @@ using UnityEngine;
 public class Spore : MonoBehaviour
 {
 
-    public delegate void SporeCollided();
-    public static event SporeCollided OnSporeDestroyed;
+    /*public delegate void SporeCollided();
+    public static event SporeCollided OnSporeDestroyed;*/
 
     [Range(0, -10)]
     public float customGravity;
@@ -71,7 +71,7 @@ public class Spore : MonoBehaviour
 
     protected virtual void SporeCollisionEvents()
     {
-        OnSporeDestroyed();
+        //OnSporeDestroyed();
     }
 
 
@@ -82,4 +82,9 @@ public class Spore : MonoBehaviour
 
     public float GetCustomGravity() => customGravity;
     public float GetThrowSpeed() => throwSpeed;
+
+    public virtual bool CanBeThrown()
+    {
+        return instance == null;
+    }
 }

--- a/Assets/Scripts/Spores/Spore.cs
+++ b/Assets/Scripts/Spores/Spore.cs
@@ -54,7 +54,7 @@ public class Spore : MonoBehaviour
         yield return new WaitForSeconds(lifeDuration);
         if(this != null)
         {
-            Destroy(gameObject);
+            Destroy(this.gameObject);
         }
     }
 
@@ -75,7 +75,7 @@ public class Spore : MonoBehaviour
     }
 
 
-    private void OnDestroy()
+    public virtual void OnDestroy()
     {
         instance = null;
     }

--- a/Assets/Scripts/Spores/SporeItemManager.cs
+++ b/Assets/Scripts/Spores/SporeItemManager.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SporeItemManager : MonoBehaviour
+{
+    public static SporeItemManager instance;
+
+    private void Awake()
+    {
+        if(instance == null)
+        {
+            instance = this;
+        }
+    }
+
+    public bool CanThrow()
+    {
+        return SporeSelect.instance.mainSpore.HasSufficientCharge();
+    }
+
+    public void PayCharge()
+    {
+        SporeSelect.instance.mainSpore.TakeCharge();
+    }
+}

--- a/Assets/Scripts/Spores/SporeItemManager.cs
+++ b/Assets/Scripts/Spores/SporeItemManager.cs
@@ -16,7 +16,13 @@ public class SporeItemManager : MonoBehaviour
 
     public bool CanThrow()
     {
-        return SporeSelect.instance.mainSpore.HasSufficientCharge();
+        return SporeSelect.instance.CanThrowCurrentSpore();
+    }
+
+    public Spore GetCurrentSpore()
+    {
+        PayCharge();
+        return SporeSelect.instance.mainSpore.sporePrefab;
     }
 
     public void PayCharge()

--- a/Assets/Scripts/Spores/SporeItemManager.cs
+++ b/Assets/Scripts/Spores/SporeItemManager.cs
@@ -27,6 +27,6 @@ public class SporeItemManager : MonoBehaviour
 
     public void PayCharge()
     {
-        SporeSelect.instance.mainSpore.TakeCharge();
+        SporeSelect.instance.mainSpore.HandleCharge();
     }
 }

--- a/Assets/Scripts/Spores/SporeItemManager.cs.meta
+++ b/Assets/Scripts/Spores/SporeItemManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb6c33fea96540b48a1189e87dd5e92b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spores/TeleportSpore.cs
+++ b/Assets/Scripts/Spores/TeleportSpore.cs
@@ -7,10 +7,20 @@ public class TeleportSpore : Spore
     public delegate void TeleportSporeCollided(Vector3 collisionPoint);
     public static event TeleportSporeCollided OnTeleportSporeCollided;
 
+    public delegate void TeleportSporeDestroyed();
+    public static event TeleportSporeDestroyed OnTeleportSporeDestroyed;
+
     protected override void SporeCollisionEvents()
     {
         base.SporeCollisionEvents();
         OnTeleportSporeCollided(transform.position);
         ThrowTest.instance.StartCooldown();
+        OnTeleportSporeDestroyed();
+    }
+
+    public override void OnDestroy()
+    {
+        OnTeleportSporeDestroyed();
+        base.OnDestroy();
     }
 }

--- a/Assets/Scripts/Spores/TeleportSpore.cs
+++ b/Assets/Scripts/Spores/TeleportSpore.cs
@@ -11,5 +11,6 @@ public class TeleportSpore : Spore
     {
         base.SporeCollisionEvents();
         OnTeleportSporeCollided(transform.position);
+        ThrowTest.instance.StartCooldown();
     }
 }

--- a/Assets/Scripts/UI/SporeItem.cs
+++ b/Assets/Scripts/UI/SporeItem.cs
@@ -69,7 +69,7 @@ public class SporeItem : MonoBehaviour
 
     public bool HasSufficientCharge()
     {
-        return currentCharge - chargeTakenPerUse > 0;
+        return currentCharge - chargeTakenPerUse >= 0;
     }
 
     public void TakeCharge()
@@ -79,5 +79,18 @@ public class SporeItem : MonoBehaviour
         currentCharge = (newCurrentCharge > 0) ? newCurrentCharge : 0;
         StopAllCoroutines();
         StartCoroutine(CheckCharge());
+    }
+
+    public bool CanThrowCurrentSpore()
+    {
+        Debug.Log(sporePrefab.GetType() == typeof(TeleportSpore));
+        if(sporePrefab.GetType() == typeof(TeleportSpore))
+        {
+            return Spore.instance == null;
+        }
+        else
+        {
+            return HasSufficientCharge();
+        }
     }
 }

--- a/Assets/Scripts/UI/SporeItem.cs
+++ b/Assets/Scripts/UI/SporeItem.cs
@@ -19,4 +19,51 @@ public class SporeItem : MonoBehaviour
 
     public AudioClip SelectSound;
 
+    public float maxCharge = 100f;
+    public float currentCharge;
+
+    public float chargeTakenPerUse;
+    public float chargeDelay;
+    public float rechargeRatePerSec;
+    
+
+    private void Start()
+    {
+        if(currentCharge < maxCharge)
+        {
+            Debug.Log("Starting charge from: " + gameObject.name);
+            StartCoroutine(CheckCharge());
+        }
+    }
+
+    private IEnumerator CheckCharge()
+    {
+        if(currentCharge < maxCharge)
+        {
+            yield return StartCoroutine(ChargeDelay());
+            yield return StartCoroutine(Charge());
+        }
+    }
+
+    private IEnumerator ChargeDelay()
+    {
+        Debug.Log("Entered ChargeDelay");
+        float timeRemaining = chargeDelay;
+        do
+        {
+            timeRemaining -= Time.deltaTime;
+            yield return null;
+        } while (timeRemaining > 0);
+    }
+
+    private IEnumerator Charge()
+    {
+        Debug.Log("Entered Charge");
+        do
+        {
+            currentCharge += rechargeRatePerSec * Time.deltaTime;
+            yield return null;
+        } while (currentCharge < maxCharge);
+        currentCharge = maxCharge;
+    }
 }

--- a/Assets/Scripts/UI/SporeItem.cs
+++ b/Assets/Scripts/UI/SporeItem.cs
@@ -29,7 +29,8 @@ public class SporeItem : MonoBehaviour
 
     private void Start()
     {
-        if(currentCharge < maxCharge)
+        TeleportSpore.OnTeleportSporeDestroyed += SetMaxCharge;
+        if (currentCharge < maxCharge)
         {
             Debug.Log("Starting charge from: " + gameObject.name);
             StartCoroutine(CheckCharge());
@@ -74,11 +75,34 @@ public class SporeItem : MonoBehaviour
 
     public void TakeCharge()
     {
-        Debug.Log("Entered Take Charge");
+        //Debug.Log("Entered Take Charge");
         float newCurrentCharge = currentCharge - chargeTakenPerUse;
         currentCharge = (newCurrentCharge > 0) ? newCurrentCharge : 0;
         StopAllCoroutines();
         StartCoroutine(CheckCharge());
+    }
+
+    public void TakeMaxCharge()
+    {
+        currentCharge = 0;
+        StopAllCoroutines();
+    }
+
+    public void SetMaxCharge()
+    {
+        currentCharge = 100;
+    }
+
+    public void HandleCharge()
+    {
+        if(sporePrefab.GetType() == typeof(TeleportSpore))
+        {
+            TakeMaxCharge();
+        }
+        else
+        {
+            TakeCharge();
+        }
     }
 
     public bool CanThrowCurrentSpore()
@@ -92,5 +116,9 @@ public class SporeItem : MonoBehaviour
         {
             return HasSufficientCharge();
         }
+    }
+    private void OnDestroy()
+    {
+        TeleportSpore.OnTeleportSporeDestroyed -= SetMaxCharge;
     }
 }

--- a/Assets/Scripts/UI/SporeItem.cs
+++ b/Assets/Scripts/UI/SporeItem.cs
@@ -13,7 +13,7 @@ public class SporeItem : MonoBehaviour
 {
     public Sprite sporeSprite;
 
-    public GameObject sporePrefab;
+    public Spore sporePrefab;
 
     public SporeType sporeType;
 
@@ -65,5 +65,19 @@ public class SporeItem : MonoBehaviour
             yield return null;
         } while (currentCharge < maxCharge);
         currentCharge = maxCharge;
+    }
+
+    public bool HasSufficientCharge()
+    {
+        return currentCharge - chargeTakenPerUse > 0;
+    }
+
+    public void TakeCharge()
+    {
+        Debug.Log("Entered Take Charge");
+        float newCurrentCharge = currentCharge - chargeTakenPerUse;
+        currentCharge = (newCurrentCharge > 0) ? newCurrentCharge : 0;
+        StopAllCoroutines();
+        StartCoroutine(CheckCharge());
     }
 }

--- a/Assets/Scripts/UI/SporeItemUI.cs
+++ b/Assets/Scripts/UI/SporeItemUI.cs
@@ -9,7 +9,7 @@ public class SporeItemUI : MonoBehaviour
     public Image sliderImageSlot;
     [SerializeField] private SporeItem sporeItem;
 
-    private void Awake()
+    private void Start()
     {
         // Have sporeItem be assigned on Awake from the SporeUIManager
 

--- a/Assets/Scripts/UI/SporeItemUI.cs
+++ b/Assets/Scripts/UI/SporeItemUI.cs
@@ -9,6 +9,9 @@ public class SporeItemUI : MonoBehaviour
     public Image sliderImageSlot;
     [SerializeField] private SporeItem sporeItem;
 
+    private Color white = Color.white;
+    private Color grey = new Color(0.7f, 0.7f, 1f);
+
     private void Start()
     {
         // Have sporeItem be assigned on Awake from the SporeUIManager
@@ -20,6 +23,7 @@ public class SporeItemUI : MonoBehaviour
     private void Update()
     {
         SetCharge();
+        SetColor();
     }
 
     public void SetSporeItem(SporeItem spore)
@@ -31,5 +35,17 @@ public class SporeItemUI : MonoBehaviour
     {
         float newValue = sporeItem.maxCharge - sporeItem.currentCharge;
         chargebar.value = newValue;
+    }
+
+    public void SetColor()
+    {
+        if(sporeItem.currentCharge >= sporeItem.chargeTakenPerUse)
+        {
+            sliderImageSlot.color = white;
+        }
+        else
+        {
+            sliderImageSlot.color = grey;
+        }
     }
 }

--- a/Assets/Scripts/UI/SporeItemUI.cs
+++ b/Assets/Scripts/UI/SporeItemUI.cs
@@ -32,5 +32,4 @@ public class SporeItemUI : MonoBehaviour
         float newValue = sporeItem.maxCharge - sporeItem.currentCharge;
         chargebar.value = newValue;
     }
-
 }

--- a/Assets/Scripts/UI/SporeItemUI.cs
+++ b/Assets/Scripts/UI/SporeItemUI.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class SporeItemUI : MonoBehaviour
+{
+    [SerializeField] private Slider chargebar;
+    public Image sliderImageSlot;
+    [SerializeField] private SporeItem sporeItem;
+
+    private void Awake()
+    {
+        // Have sporeItem be assigned on Awake from the SporeUIManager
+
+        sliderImageSlot = chargebar.GetComponentInChildren<Image>();
+        sliderImageSlot.sprite = sporeItem.sporeSprite;
+    }
+
+    private void Update()
+    {
+        SetCharge();
+    }
+
+    public void SetSporeItem(SporeItem spore)
+    {
+        sporeItem = spore;
+    }
+
+    public void SetCharge()
+    {
+        float newValue = sporeItem.maxCharge - sporeItem.currentCharge;
+        chargebar.value = newValue;
+    }
+
+}

--- a/Assets/Scripts/UI/SporeItemUI.cs
+++ b/Assets/Scripts/UI/SporeItemUI.cs
@@ -6,6 +6,7 @@ using UnityEngine.UI;
 public class SporeItemUI : MonoBehaviour
 {
     [SerializeField] private Slider chargebar;
+    public Image fill;
     public Image sliderImageSlot;
     [SerializeField] private SporeItem sporeItem;
 

--- a/Assets/Scripts/UI/SporeItemUI.cs.meta
+++ b/Assets/Scripts/UI/SporeItemUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c772d0fbcaa7bf49a1b6f3c27bfe96f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/SporeSelect.cs
+++ b/Assets/Scripts/UI/SporeSelect.cs
@@ -10,6 +10,7 @@ public class SporeSelect : MonoBehaviour
     SporeItem rightSpore;
     private ThrowTest throwTest;
     bool isSwitching = false;
+    [Space]
 
     public SporeItemUI mainSporeItemUI;
     public SporeItemUI leftSporeItemUI;
@@ -36,8 +37,9 @@ public class SporeSelect : MonoBehaviour
     {
         throwTest = FindObjectOfType<ThrowTest>();
         SetSpores();
-        mainSporeIndex = 0;
+        mainSporeIndex = 0;  
         UpdateUI();
+        UpdateEnabledSporeSprites();
     }
 
     void Update()
@@ -65,7 +67,9 @@ public class SporeSelect : MonoBehaviour
 
     private void SetSpores()
     {
-        if(sporesList.Count == 0)
+        leftSpore = null;
+        rightSpore = null;
+        if (sporesList.Count == 0)
             return;
 
         if(sporesList.Count == 1)
@@ -99,6 +103,7 @@ public class SporeSelect : MonoBehaviour
         sporesList.Add(spore);
         UpdateSpores();
         UpdateUI();
+        UpdateEnabledSporeSprites();
     }
 
     private void LeftSwap()
@@ -172,39 +177,21 @@ public class SporeSelect : MonoBehaviour
         if (sporesList.Count == 0)
         {
             SetSlotValues(false, false, false);
-            /*mainSporeSlot.enabled = false;
-            leftSporeSlot.enabled = false;
-            rightSporeSlot.enabled = false;*/
         }
         else if (sporesList.Count == 1)
         {
             SetSlotValues(false, true, false);
             SetSporeSprites();
-            //mainSporeSlot.enabled = true;
-            //mainSporeSlot.sprite = mainSpore.sporeSprite;
-            /*leftSporeSlot.enabled = false;
-            rightSporeSlot.enabled = false;*/
         }
         else if (sporesList.Count == 2)
         {
             SetSlotValues(true, true, false);
             SetSporeSprites();
-            /*mainSporeSlot.enabled = true;
-            leftSporeSlot.enabled = true;*/
-            /*mainSporeSlot.sprite = mainSpore.sporeSprite;
-            leftSporeSlot.sprite = leftSpore.sporeSprite;*/
-            /*rightSporeSlot.enabled = false;*/
         }
         else
         {
             SetSlotValues(true, true, true);
             SetSporeSprites();
-            /*mainSporeSlot.enabled = true;
-            leftSporeSlot.enabled = true;
-            rightSporeSlot.enabled = true;*/
-            /*mainSporeSlot.sprite = mainSpore.sporeSprite;
-            leftSporeSlot.sprite = leftSpore.sporeSprite;
-            rightSporeSlot.sprite = rightSpore.sporeSprite;*/
         }
     }
 
@@ -218,26 +205,46 @@ public class SporeSelect : MonoBehaviour
     private void SetSporeSprites()
     {
         if(leftSpore != null)
-        leftSporeItemUI.sliderImageSlot.sprite = leftSpore.sporeSprite;
+            leftSporeItemUI.sliderImageSlot.sprite = leftSpore.sporeSprite;
+    
         if(mainSpore != null)
-        mainSporeItemUI.sliderImageSlot.sprite = mainSpore.sporeSprite;
+            mainSporeItemUI.sliderImageSlot.sprite = mainSpore.sporeSprite;
+        
         if(rightSpore != null)
-        rightSporeItemUI.sliderImageSlot.sprite = rightSpore.sporeSprite;
+            rightSporeItemUI.sliderImageSlot.sprite = rightSpore.sporeSprite;
+        UpdateEnabledSporeSprites();
+    }
 
+    private void UpdateEnabledSporeSprites()
+    {
+        Debug.Log("Updating Spore UI object activeness");
+        //leftSporeItemUI.gameObject.SetActive((leftSpore != null) ? true : false);
+        Debug.Log("Is left spore Present?: " + leftSpore != null);
+        leftSporeItemUI.fill.gameObject.SetActive((leftSpore != null) ? true : false);
+
+        //mainSporeItemUI.gameObject.SetActive((mainSpore != null) ? true : false);
+        mainSporeItemUI.fill.gameObject.SetActive((mainSpore != null) ? true : false);
+        //rightSporeItemUI.gameObject.SetActive((rightSpore != null) ? true : false);
+        rightSporeItemUI.fill.gameObject.SetActive((rightSpore != null) ? true : false);
     }
 
     private void UpdateSpores()
     {
         if (mainSporeIndex >= sporesList.Count)
             mainSporeIndex = 0;
-
-        if (sporesList.Count == 2)
+        if(sporesList.Count == 1)
+        {
+            rightSpore = null;
+            mainSpore = sporesList[mainSporeIndex];
+            leftSpore = null;
+        }
+        else if (sporesList.Count == 2)
         {
             rightSpore = null;
             mainSpore = sporesList[mainSporeIndex];
             leftSpore = sporesList[(mainSporeIndex - 1 + sporesList.Count) % sporesList.Count];
         }
-        else
+        else if(sporesList.Count == 3)
         {
             mainSpore = sporesList[mainSporeIndex];
             rightSpore = sporesList[(mainSporeIndex + 1) % sporesList.Count];

--- a/Assets/Scripts/UI/SporeSelect.cs
+++ b/Assets/Scripts/UI/SporeSelect.cs
@@ -201,4 +201,9 @@ public class SporeSelect : MonoBehaviour
         //function so we can't switch 
         isSwitching = false;
     }
+
+    public bool CanThrowCurrentSpore()
+    {
+        return mainSpore.CanThrowCurrentSpore();
+    }
 }

--- a/Assets/Scripts/UI/SporeSelect.cs
+++ b/Assets/Scripts/UI/SporeSelect.cs
@@ -21,6 +21,16 @@ public class SporeSelect : MonoBehaviour
 
     public Animator animator;
 
+    public static SporeSelect instance;
+
+    private void Awake()
+    {
+        if(instance == null)
+        {
+            instance = this;
+        }
+    }
+
     void Start()
     {
         throwTest = FindObjectOfType<ThrowTest>();

--- a/Assets/Scripts/UI/SporeSelect.cs
+++ b/Assets/Scripts/UI/SporeSelect.cs
@@ -255,4 +255,9 @@ public class SporeSelect : MonoBehaviour
     {
         return mainSpore.CanThrowCurrentSpore();
     }
+
+    private void OnValidate()
+    {
+        Init();
+    }
 }

--- a/Assets/Scripts/UI/SporeSelect.cs
+++ b/Assets/Scripts/UI/SporeSelect.cs
@@ -11,9 +11,9 @@ public class SporeSelect : MonoBehaviour
     private ThrowTest throwTest;
     bool isSwitching = false;
 
-    public Image mainSporeSlot;
-    public Image leftSporeSlot;
-    public Image rightSporeSlot;
+    public SporeItemUI mainSporeItemUI;
+    public SporeItemUI leftSporeItemUI;
+    public SporeItemUI rightSporeItemUI;
 
     int mainSporeIndex = 0;
 
@@ -28,10 +28,11 @@ public class SporeSelect : MonoBehaviour
         if(instance == null)
         {
             instance = this;
+            Init();
         }
     }
 
-    void Start()
+    void Init()
     {
         throwTest = FindObjectOfType<ThrowTest>();
         SetSpores();
@@ -70,17 +71,26 @@ public class SporeSelect : MonoBehaviour
         if(sporesList.Count == 1)
         {
             mainSpore = sporesList[0];
+
+            mainSporeItemUI.SetSporeItem(mainSpore);
         }
         else if(sporesList.Count == 2)
         {
             mainSpore = sporesList[1];
             leftSpore = sporesList[0];
+
+            mainSporeItemUI.SetSporeItem(mainSpore);
+            leftSporeItemUI.SetSporeItem(leftSpore);
         }
         else
         {
             mainSpore = sporesList[1];
             leftSpore = sporesList[0];
             rightSpore = sporesList[2];
+
+            mainSporeItemUI.SetSporeItem(mainSpore);
+            leftSporeItemUI.SetSporeItem(leftSpore);
+            rightSporeItemUI.SetSporeItem(rightSpore);
         }
     }
 
@@ -106,6 +116,9 @@ public class SporeSelect : MonoBehaviour
             rightSpore = null;
             mainSpore = sporesList[mainSporeIndex];
             leftSpore = sporesList[(mainSporeIndex - 1 + sporesList.Count) % sporesList.Count];
+
+            mainSporeItemUI.SetSporeItem(mainSpore);
+            leftSporeItemUI.SetSporeItem(leftSpore);
         }
         else
         {
@@ -113,6 +126,10 @@ public class SporeSelect : MonoBehaviour
             mainSpore = sporesList[mainSporeIndex];
             rightSpore = sporesList[(mainSporeIndex + 1) % sporesList.Count];
             leftSpore = sporesList[(mainSporeIndex - 1 + sporesList.Count) % sporesList.Count];
+
+            mainSporeItemUI.SetSporeItem(mainSpore);
+            leftSporeItemUI.SetSporeItem(leftSpore);
+            rightSporeItemUI.SetSporeItem(rightSpore);
         }
         isSwitching = true;
     }
@@ -132,6 +149,9 @@ public class SporeSelect : MonoBehaviour
             rightSpore = null;
             mainSpore = sporesList[mainSporeIndex];
             leftSpore = sporesList[(mainSporeIndex - 1 + sporesList.Count) % sporesList.Count];
+
+            mainSporeItemUI.SetSporeItem(mainSpore);
+            leftSporeItemUI.SetSporeItem(leftSpore);
         }
         else
         {
@@ -139,6 +159,10 @@ public class SporeSelect : MonoBehaviour
             mainSpore = sporesList[mainSporeIndex];
             rightSpore = sporesList[(mainSporeIndex + 1) % sporesList.Count];
             leftSpore = sporesList[(mainSporeIndex - 1 + sporesList.Count) % sporesList.Count];
+
+            mainSporeItemUI.SetSporeItem(mainSpore);
+            leftSporeItemUI.SetSporeItem(leftSpore);
+            rightSporeItemUI.SetSporeItem(rightSpore);
         }
         isSwitching = true;
     }
@@ -147,34 +171,59 @@ public class SporeSelect : MonoBehaviour
     {
         if (sporesList.Count == 0)
         {
-            mainSporeSlot.enabled = false;
+            SetSlotValues(false, false, false);
+            /*mainSporeSlot.enabled = false;
             leftSporeSlot.enabled = false;
-            rightSporeSlot.enabled = false;
+            rightSporeSlot.enabled = false;*/
         }
         else if (sporesList.Count == 1)
         {
-            mainSporeSlot.enabled = true;
-            mainSporeSlot.sprite = mainSpore.sporeSprite;
-            leftSporeSlot.enabled = false;
-            rightSporeSlot.enabled = false;
+            SetSlotValues(false, true, false);
+            SetSporeSprites();
+            //mainSporeSlot.enabled = true;
+            //mainSporeSlot.sprite = mainSpore.sporeSprite;
+            /*leftSporeSlot.enabled = false;
+            rightSporeSlot.enabled = false;*/
         }
         else if (sporesList.Count == 2)
         {
-            mainSporeSlot.enabled = true;
-            leftSporeSlot.enabled = true;
-            mainSporeSlot.sprite = mainSpore.sporeSprite;
-            leftSporeSlot.sprite = leftSpore.sporeSprite;
-            rightSporeSlot.enabled = false;
+            SetSlotValues(true, true, false);
+            SetSporeSprites();
+            /*mainSporeSlot.enabled = true;
+            leftSporeSlot.enabled = true;*/
+            /*mainSporeSlot.sprite = mainSpore.sporeSprite;
+            leftSporeSlot.sprite = leftSpore.sporeSprite;*/
+            /*rightSporeSlot.enabled = false;*/
         }
         else
         {
-            mainSporeSlot.enabled = true;
+            SetSlotValues(true, true, true);
+            SetSporeSprites();
+            /*mainSporeSlot.enabled = true;
             leftSporeSlot.enabled = true;
-            rightSporeSlot.enabled = true;
-            mainSporeSlot.sprite = mainSpore.sporeSprite;
+            rightSporeSlot.enabled = true;*/
+            /*mainSporeSlot.sprite = mainSpore.sporeSprite;
             leftSporeSlot.sprite = leftSpore.sporeSprite;
-            rightSporeSlot.sprite = rightSpore.sporeSprite;
+            rightSporeSlot.sprite = rightSpore.sporeSprite;*/
         }
+    }
+
+    private void SetSlotValues(bool leftActive, bool mainActive, bool rightActive)
+    {
+        leftSporeItemUI.sliderImageSlot.enabled = leftActive;
+        mainSporeItemUI.sliderImageSlot.enabled = mainActive;
+        rightSporeItemUI.sliderImageSlot.enabled = rightActive;
+    }
+
+    private void SetSporeSprites()
+    {
+        if(leftSpore != null)
+        leftSporeItemUI.sliderImageSlot.sprite = leftSpore.sporeSprite;
+        if(mainSpore != null)
+        mainSporeItemUI.sliderImageSlot.sprite = mainSpore.sporeSprite;
+        if(rightSpore != null)
+        rightSporeItemUI.sliderImageSlot.sprite = rightSpore.sporeSprite;
+
     }
 
     private void UpdateSpores()

--- a/Assets/Sprites/UI.meta
+++ b/Assets/Sprites/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f612d128163e75b408324e28b3dbed8c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Charge System
* Implemented A Charge System for the Fire Spore and Cordyceps Spore, where firing a spore takes some of that spore type's charge.

* In short, the player can rapidly fire 4 Fire Spores and 2 Cordyceps Spores.

## Charge Bar Visuals
* These charge bars are visible on the Spore UI Icons.

* When a spore doesn't have sufficient charge to be thrown, it's UI visual dims further.

* The Telespore's charge bar is empty only when it's thrown.

---

## Current Cordyceps Spore values:
chargeTakenPerUse = 25f;
chargeDelay = 3f;
rechargeRatePerSec = 33f;

## Current Cordyceps Spore values:
chargeTakenPerUse = 50f;
chargeDelay = 1f;
rechargeRatePerSec = 10f;

## Telespore values

The Telespore uses a separate system for handling charge, so it's chargeDelay and rechargeRatePerSec won't affect it.